### PR TITLE
Use link_shared_object instead of link_executable in SQLite detection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ def _have_sqlite_extension_support():
     customize_compiler(compiler)
     success = False
     try:
-        compiler.link_executable(
+        compiler.link_shared_object(
             compiler.compile([src_file], output_dir=tmp_dir),
             bin_file,
             libraries=['sqlite3'])


### PR DESCRIPTION
`link_executable` doesn't use environment variable `LDFLAGS`, only environment variable `CC`… which can be an issue and cause false negative on setups where SQLite is not built in system path